### PR TITLE
Create .gitattributes to remove ShaderLab

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+* linguist-vendored
+*.cs linguist-vendored=false


### PR DESCRIPTION
I created a .gitattributes file that makes the repository stop showing that the "shaderlab" language was used, since the shaderlab is added automatically because you have worked with URP. the focus of the project is c# and not shaderLab, this will give a greater prominence to the codes you made.